### PR TITLE
Export the Signal class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -258,7 +258,7 @@ function clearSignalData(obj: any): void {
 /**
  * A concrete implementation of ISignal.
  */
-class Signal implements ISignal<any> {
+export class Signal implements ISignal<any> {
   /**
    * Construct a new signal.
    */


### PR DESCRIPTION
This changes enables signals to be declared in ES6 (no decorators present):

```javascript
  get itemAdded() {
    var token = {};
    return new Signal(this, token);
  }
```